### PR TITLE
Use Maven batch mode

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,6 @@ environment:
     secure: LILHLHOw9/K+6tCSUm3w8Yqv38LcAXaT/hXsn4BCBVqXUAzWu3M07qPeitumudWT
 
 build_script:
-  - cmd: mvn clean install && java -jar target\travis-scheduler-1.0-SNAPSHOT.jar
+  - cmd: mvn -B clean install && java -jar target\travis-scheduler-1.0-SNAPSHOT.jar
 
 test: off


### PR DESCRIPTION
This prevents cluttering of build log with useless messages about progress of downloading of artifacts.
